### PR TITLE
tests: Use correct channel for cos-lite.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -176,6 +176,17 @@ jobs:
               bootstrap: true
           EOF
 
+          # Workaround for canonical/concierge#75
+          sudo snap install microk8s --channel 1.32-strict/stable
+          sudo mkdir -p /var/snap/microk8s/current/args/certs.d/docker.io
+          cat <<EOF | sudo tee /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml
+          server = "$DOCKERHUB_MIRROR"
+          [host."$DOCKERHUB_MIRROR"]
+          capabilities = ["pull", "resolve"]
+          EOF
+          sudo microk8s stop
+          sudo microk8s start
+
           sudo concierge prepare -c /tmp/concierge.yaml
 
           # Create second bridged network needed by the functional tests

--- a/src/tests/bundles/cos-lite.yaml
+++ b/src/tests/bundles/cos-lite.yaml
@@ -8,17 +8,17 @@ applications:
     charm: traefik-k8s
     scale: 1
     trust: true
-    channel: stable
+    channel: 1.0/stable
   prometheus:
     charm: prometheus-k8s
     scale: 1
     trust: true
-    channel: stable
+    channel: 1/stable
   grafana:
     charm: grafana-k8s
     scale: 1
     trust: true
-    channel: stable
+    channel: 1/stable
 
 relations:
 - [traefik:ingress-per-unit, prometheus:ingress]

--- a/src/tests/bundles/noble-caracal.yaml
+++ b/src/tests/bundles/noble-caracal.yaml
@@ -30,7 +30,7 @@ applications:
 
   grafana-agent:
     charm: ch:grafana-agent
-    channel: latest/stable
+    channel: 1/stable
     base: ubuntu@24.04
 
 relations:


### PR DESCRIPTION
The cos-lite charms have recently closed their `latest/stable` channel, and consequently deployment fails.

Use specific track for all charms in the bundle.